### PR TITLE
allow layouts to access context

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export type LayoutHandler<N = Node> = (props: {
   children: N | string
   head: Head<N>
   filename: string
+  c: LayoutContext
 }) => N | string | Promise<N | string>
 
 /** Function Handler */
@@ -68,3 +69,5 @@ export type Route<E extends Env = Env, N = Node> = {
 }
 
 export type AppRoute<E extends Env = Env> = (app: Hono<E>) => void
+
+export type LayoutContext = Omit<Context | 'render', 'setRenderer'>


### PR DESCRIPTION
Every handler except `LayoutHandler` can receive `Context` as a parameter. This PR allow LayoutHandler to access `Context` as well.

I know that I'm hasty and need more discussion. I just want to show you what I want by code!

## Background

I'm working on https://github.com/kuma-ui/kuma-ui/pull/364. I'd like to use `Context` as a request-scoped dictionary in `LayoutHandler` to provide elegant API.

Rough example:
```tsx
const handler: LayoutHandler = ({ children, head, c }) => {
  return (
    <KumaRegistry context={c}>
      <html lang="en">
        <head>
          {head.createTags()}
          <KumaHead context={c} />
        </head>
        <body>...</body>
      </html>
    </KumaRegistry>
  );
}
```