### PR TITLE
refactor: support async `renderToString`

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -142,7 +142,7 @@ export const createApp = <E extends Env>(options: ServerOptions<E>): Hono<E> => 
       }
     }
 
-    const content = render(innerContent)
+    const content = await render(innerContent)
 
     if (typeof content === 'string') {
       if (defaultLayout || layouts?.length) {
@@ -158,7 +158,7 @@ export const createApp = <E extends Env>(options: ServerOptions<E>): Hono<E> => 
   if (options.setDefaultRenderer === true) {
     app.use('*', async (c, next) => {
       c.setRenderer(async (node) => {
-        return createResponse(c, render(node))
+        return createResponse(c, await render(node))
       })
       await next()
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export type Methods = 'GET' | 'POST' | 'PUT' | 'DELETE'
 /** JSX */
 export type CreateElement = (type: any, props: any, ...children: any[]) => Node
 export type FragmentType = any
-export type RenderToString<N = Node> = (node: N) => string
+export type RenderToString<N = Node> = (node: N) => string | Promise<string>
 export type RenderToReadableStream<N = Node> = (node: N, options?: any) => Promise<ReadableStream>
 export type Hydrate = (children: Node, parent: Element) => void
 


### PR DESCRIPTION
Some frameworks are exporting the async `renderToString` function (e.g. [Qwik](https://qwik.builder.io/api/qwik-server/#rendertostring), [SolidJS](https://docs.solidjs.com/references/api-reference/rendering/renderToStringAsync))